### PR TITLE
Add engine component tests

### DIFF
--- a/test/column.test.js
+++ b/test/column.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { uniqueId, uniqueIdDate } from '../engine/column.js';
+
+test('uniqueId length and date extraction', () => {
+  const id = uniqueId('foo');
+  assert.equal(id.length, 24);
+  const d = uniqueIdDate(id);
+  assert(d instanceof Date);
+  assert.ok(!Number.isNaN(d.getTime()));
+});

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Database } from '../engine/database.js';
+import { Schema } from '../engine/schema.js';
+import { Types } from '../engine/column.js';
+
+async function createTempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'bindb-'));
+}
+
+test('database metadata persistence', async () => {
+  const dir = await createTempDir();
+  const db = await Database.create(dir, 'testdb');
+  const schema = Schema.create('testdb', 'items', [
+    { name: 'name', type: Types.Text, length: 10 },
+  ]);
+  await db.createTable('items', schema);
+  const metadataPath = path.join(dir, 'testdb', 'db_metadata.json');
+  const stat = await fs.stat(metadataPath);
+  assert.ok(stat.isFile());
+
+  const db2 = new Database(dir, 'testdb');
+  await db2.initDatabase();
+  assert.ok(db2.table('items'));
+});

--- a/test/row.test.js
+++ b/test/row.test.js
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Schema } from '../engine/schema.js';
+import { Types } from '../engine/column.js';
+import {
+  parseBufferSchema,
+  dataRowToBuffer,
+  parseDataRow,
+  RowStatus,
+} from '../engine/row.js';
+
+test('data row round trip', () => {
+  const schema = Schema.create('db', 'items', [
+    { name: 'name', type: Types.Text, length: 10 },
+    { name: 'value', type: Types.Number },
+    { name: 'flag', type: Types.Boolean },
+    { name: 'when', type: Types.Date },
+  ]);
+  const bufferSchema = parseBufferSchema(schema);
+  const row = {
+    name: 'foo',
+    value: 42,
+    flag: true,
+    when: new Date('2020-01-02T00:00:00Z'),
+  };
+  const buf = dataRowToBuffer(bufferSchema, row);
+  const parsed = parseDataRow(bufferSchema, buf);
+  assert.equal(parsed.name, row.name);
+  assert.equal(parsed.value, row.value);
+  assert.equal(parsed.flag, row.flag);
+  assert.equal(parsed.when.getTime(), row.when.getTime());
+  assert.ok(parsed.id);
+  assert.equal(parsed.id.length, 24);
+});
+
+test('parse deleted row', () => {
+  const schema = Schema.create('db', 'items', [
+    { name: 'name', type: Types.Text, length: 10 },
+  ]);
+  const bufferSchema = parseBufferSchema(schema);
+  const buf = dataRowToBuffer(bufferSchema, { name: 'foo' }, RowStatus.Deleted);
+  assert.equal(parseDataRow(bufferSchema, buf), null);
+});
+
+test('parseDataRow error cases', () => {
+  const schema = Schema.create('db', 'items', [
+    { name: 'name', type: Types.Text, length: 10 },
+  ]);
+  const bufferSchema = parseBufferSchema(schema);
+  assert.throws(
+    () => parseDataRow(bufferSchema, Buffer.alloc(bufferSchema.size - 1)),
+    /Buffer size mismatch/
+  );
+  const buf = Buffer.alloc(bufferSchema.size);
+  buf.writeUInt8(0xfe, 0); // invalid flag
+  assert.throws(
+    () => parseDataRow(bufferSchema, buf),
+    /Invalid row flag/
+  );
+});

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Schema } from '../engine/schema.js';
+import { Types } from '../engine/column.js';
+
+
+test('Schema create and toJSON/fromJSON', () => {
+  const schema = Schema.create('db', 'items', [
+    { name: 'name', type: Types.Text, length: 10 },
+  ]);
+  assert.equal(schema.database, 'db');
+  assert.equal(schema.table, 'items');
+  assert.equal(schema.columns.length, 1);
+  const json = schema.toJSON();
+  const loaded = Schema.fromJSON(json);
+  assert.deepEqual(loaded.toJSON(), json);
+});
+
+test('Schema addColumn validation', () => {
+  const schema = new Schema();
+  schema.database = 'db';
+  schema.table = 'items';
+  schema.addColumn({ name: 'name', type: Types.Text, length: 10 });
+  assert.throws(
+    () => schema.addColumn({ name: 'name', type: Types.Text, length: 5 }),
+    /already exists/
+  );
+  assert.throws(
+    () => schema.addColumn({ name: 'other', type: 'Nope' }),
+    /Invalid type/
+  );
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { strHash } from '../engine/util.js';
+
+test('strHash deterministic and length', () => {
+  const h1 = strHash(4, 'foo', 'bar');
+  const h2 = strHash(4, 'foo', 'bar');
+  assert.equal(h1.length, 8);
+  assert.equal(h1, h2);
+});


### PR DESCRIPTION
## Summary
- add coverage for uniqueId and util hashing helpers
- test Schema creation and validation
- test buffer row conversions and error handling
- validate database metadata persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab97c86788331b048edd896a332b6