### PR TITLE
Fix dockerfile npm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install all dependencies (including dev dependencies for build)
-RUN npm ci && npm cache clean --force
+RUN npm ci
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Remove `npm cache clean --force` from Dockerfile builder stage to ensure dev dependencies are available for build.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-c86a3894-71a3-4532-86f2-613e9150bd90) · [Cursor](https://cursor.com/background-agent?bcId=bc-c86a3894-71a3-4532-86f2-613e9150bd90)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)