### PR TITLE
Fix admin interface file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN npm ci --only=production && npm cache clean --force
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
 
+# Copy admin.html to the app directory
+COPY --from=builder /app/admin.html ./admin.html
+
 # Change ownership to nodejs user
 RUN chown -R nodejs:nodejs /app
 


### PR DESCRIPTION
Copy `admin.html` to the Docker image to fix the 'no such file or directory' error for the `/admin` endpoint.

The `/admin` endpoint was failing with an `ENOENT: no such file or directory, open '/app/admin.html'` error because the `admin.html` file was not being copied into the Docker container during the build process. This change ensures the file is present in the container's working directory.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-eb74ef6c-454a-4b95-a544-33536d9f9abb) · [Cursor](https://cursor.com/background-agent?bcId=bc-eb74ef6c-454a-4b95-a544-33536d9f9abb)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)