### PR TITLE
Correct admin endpoint HTML response

### DIFF
--- a/http/engine-api.ts
+++ b/http/engine-api.ts
@@ -366,7 +366,7 @@ export class EngineAPI {
    */
   private registerUtilityRoutes(app: App): void {
     // Admin interface
-    app.get('/admin', async _req => {
+    app.get('/v1/admin', async _req => {
       try {
         const fs = await import('fs/promises');
         const path = await import('path');
@@ -376,7 +376,7 @@ export class EngineAPI {
         return {
           statusCode: 200,
           headers: {
-            'Content-Type': 'text/html',
+            'Content-Type': 'text/html; charset=utf-8',
             'Cache-Control': 'no-cache',
           },
           body: adminHtml,

--- a/http/response-formatter.ts
+++ b/http/response-formatter.ts
@@ -17,11 +17,29 @@ export class ResponseFormatter {
     }
 
     if (typeof result === 'object') {
+      // Check if result is already a pre-formatted HttpResponse
+      if (this.isHttpResponse(result)) {
+        return result;
+      }
+      
       return this.createJsonResponse(result, origin);
     }
 
     // Fallback for other types
     return this.createTextResponse(String(result));
+  }
+
+  /**
+   * Check if an object is a pre-formatted HttpResponse
+   */
+  private isHttpResponse(obj: any): obj is HttpResponse {
+    return (
+      obj &&
+      typeof obj === 'object' &&
+      typeof obj.statusCode === 'number' &&
+      (obj.headers === undefined || typeof obj.headers === 'object') &&
+      (obj.body === undefined || typeof obj.body === 'string' || Buffer.isBuffer(obj.body))
+    );
   }
 
   createEmptyResponse(): HttpResponse {

--- a/http/response-formatter.ts
+++ b/http/response-formatter.ts
@@ -21,7 +21,7 @@ export class ResponseFormatter {
       if (this.isHttpResponse(result)) {
         return result;
       }
-      
+
       return this.createJsonResponse(result, origin);
     }
 
@@ -38,7 +38,9 @@ export class ResponseFormatter {
       typeof obj === 'object' &&
       typeof obj.statusCode === 'number' &&
       (obj.headers === undefined || typeof obj.headers === 'object') &&
-      (obj.body === undefined || typeof obj.body === 'string' || Buffer.isBuffer(obj.body))
+      (obj.body === undefined ||
+        typeof obj.body === 'string' ||
+        Buffer.isBuffer(obj.body))
     );
   }
 


### PR DESCRIPTION
Fix admin endpoint to serve HTML correctly and align its route with API standards.

The admin endpoint was returning an HTML response wrapped in a structured object, which the `ResponseFormatter` incorrectly converted to JSON. This PR modifies the formatter to recognize pre-formatted `HttpResponse` objects, ensures the admin endpoint returns the correct `Content-Type` header, and aligns its route with the `/v1/` API prefix.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-82ac50a1-c58f-4a89-9fdd-804591129958) · [Cursor](https://cursor.com/background-agent?bcId=bc-82ac50a1-c58f-4a89-9fdd-804591129958)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)